### PR TITLE
always stop txthreadworker, even after unexpected exceptions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: python -m pip install -q Twisted
+      - name: Run txconnectionpool tests
+        run: trial txconnectionpool
       - name: Run test
         run: trial twistar

--- a/txconnectionpool/tests/test_txconnectionpool.py
+++ b/txconnectionpool/tests/test_txconnectionpool.py
@@ -1,0 +1,86 @@
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from txconnectionpool.txconnectionpool import TxConnectionPool
+
+
+class FakeTxnError(Exception):
+    pass
+
+
+class FailingToStartConnection(object):
+    def __init__(self, _pool):
+        raise FakeTxnError('fake connection excpected failure')
+
+
+class FakeCursor(object):
+    def close(self):
+        pass
+
+
+class FailingToCommitOrRollbackConnection(object):
+    def __init__(self, _pool):
+        pass
+
+    def cursor(self):
+        return FakeCursor()
+
+    def reconnect(self):
+        pass
+
+    def rollback(self):
+        raise FakeTxnError('fake connection expected failure')
+
+    def commit(self):
+        raise FakeTxnError('fake connection expected failure')
+
+
+class TxConnectionPoolTest(unittest.TestCase):
+    def test_failure_to_start_txn_will_release_thread(self):
+        cp = TxConnectionPool('sqlite3')
+        cp.max = 1
+        cp.connectionFactory = FailingToStartConnection
+
+        d = cp.startTransaction()
+        self.assertFailure(d, FakeTxnError)
+
+        d = cp.startTransaction()
+        self.assertFailure(d, FakeTxnError)
+
+        return d
+
+    @defer.inlineCallbacks
+    def test_failure_to_commit_will_release_thread(self):
+        cp = TxConnectionPool('sqlite3')
+        cp.max = 1
+        cp.connectionFactory = FailingToCommitOrRollbackConnection
+
+        txn = yield cp.startTransaction()
+        d = cp.commitTransaction(txn)
+        self.assertFailure(d, FakeTxnError)
+
+        yield d
+
+        txn = yield cp.startTransaction()
+        d = cp.commitTransaction(txn)
+        self.assertFailure(d, FakeTxnError)
+
+        yield d
+
+    @defer.inlineCallbacks
+    def test_failure_to_rollback_will_release_thread(self):
+        cp = TxConnectionPool('sqlite3')
+        cp.max = 1
+        cp.connectionFactory = FailingToCommitOrRollbackConnection
+
+        txn = yield cp.startTransaction()
+        d = cp.rollbackTransaction(txn)
+        self.assertFailure(d, FakeTxnError)
+
+        yield d
+
+        txn = yield cp.startTransaction()
+        d = cp.rollbackTransaction(txn)
+        self.assertFailure(d, FakeTxnError)
+
+        yield d

--- a/txconnectionpool/txconnectionpool.py
+++ b/txconnectionpool/txconnectionpool.py
@@ -19,8 +19,8 @@ class TxConnectionPool(ConnectionPool):
         Since this connection will be in use until the Transaction is
         completed, the thread that we call the function in gets blocked
         until then.  The Semaphore it is waiting on is stored in
-        the self.transLock dictionary. 
-        """        
+        the self.transLock dictionary.
+        """
 
         warning_limit = self.threadpool.max / 10
         if len(self.threadpool.working) >= self.threadpool.max:
@@ -45,7 +45,7 @@ class TxConnectionPool(ConnectionPool):
             self.txWorkersLock.release()
 
             return t
-        
+
         d = worker.submit(initTx)
         return d
 
@@ -63,7 +63,7 @@ class TxConnectionPool(ConnectionPool):
         Execute the specified function into the transaction thread and return result
         """
         return self._deferToTrans(f, trans, *args, **kw)
-      
+
     def runOperationInTransaction(self, trans, *args, **kw):
         """Execute an SQL query in the specified Transaction and return None.
 
@@ -78,7 +78,7 @@ class TxConnectionPool(ConnectionPool):
         d = self._deferToTrans(self._commitTransaction, trans)
         d.addCallback(self._stopTxWorker)
         return d
- 
+
     def rollbackTransaction(self, trans):
         """Exit the transaction without committing."""
 
@@ -91,7 +91,7 @@ class TxConnectionPool(ConnectionPool):
                            'workers: %s' % len(self.threadpool.working),
                            'total: %s'   % len(self.threadpool.threads),
                          ])
- 
+
     def _stopTxWorker(self, worker):
         return worker.stop()
 
@@ -107,7 +107,7 @@ class TxConnectionPool(ConnectionPool):
             log.msg('Exception in SQL query %s'%args)
             log.deferr()
             raise
-     
+
     def _runOperationInTransaction(self, trans, *args, **kwargs):
         try:
             return trans.execute(*args, **kwargs)
@@ -127,7 +127,7 @@ class TxConnectionPool(ConnectionPool):
         conn.commit()
 
         return worker
-     
+
     def _rollbackTransaction(self, trans):
         if trans._cursor is None:
             raise TransactionNotStartedError("Cannot call rollback without a transaction")
@@ -153,7 +153,7 @@ class TxConnectionPool(ConnectionPool):
             self.txWorkersLock.release()
 
         return worker
- 
+
     def _deferToTrans(self, f, trans, *args, **kwargs):
         """Internal function.
 
@@ -172,5 +172,5 @@ class TxConnectionPool(ConnectionPool):
             raise e
         finally:
             self.txWorkersLock.release()
-        
+
         return d

--- a/txthreadworker/txthreadworker.py
+++ b/txthreadworker/txthreadworker.py
@@ -50,7 +50,7 @@ class TxThreadWorker(object):
 
     def stop(self):
         """
-        Start this ThreadWorker.
+        Stop this ThreadWorker.
 
         @returns: a deferred which will fire when ThreadWorker has been stopped.
         @rtype: a C{Defer}


### PR DESCRIPTION
Currently any exception raised by the db driver when starting, committin or rolling back a transaction causes the connection pool to not release the underlying thread. 

This fixes the issue by capturing the error, stopping the worker, and propagating back the exception towards the caller
